### PR TITLE
Fix: TypeError: unsupported operand type(s)

### DIFF
--- a/ckanext/search_autocomplete/utils.py
+++ b/ckanext/search_autocomplete/utils.py
@@ -109,7 +109,7 @@ def _datasets_by_terms(
         tk.config.get(CONFIG_IGNORE_SYNONYMS, DEFAULT_IGNORE_SYNONYMS)
     )
 
-    fq = fq or ""
+    fq = "" if fq is None else str(fq)
     if ignore_synonyms:
         fq += " title_ngram:({0})"
     else:


### PR DESCRIPTION
Fix error: 
File "./ckanext-search-autocomplete/ckanext/search_autocomplete/utils.py", line 117, in _datasets_by_terms
fq += " (title:({0}) OR title_ngram:({0}))"
TypeError: unsupported operand type(s) for +=: 'bool' and 'str'